### PR TITLE
Fix: bad behavior of insert() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 ### Fixed 
 
-* When `startPoint` is passed on `insert()` method of `QueryDelta`, `left` value passed is ignored.
-* When set `target` param in `insert()` method of `QueryDelta`, sometimes the target is replaced unexpectedly.
-* When set `startPoint` is passed, sometimes is ignored and will jump to the part that we want to change.
-* Wrong behavior and unexpected `Delta` results after `build()` when using complex inserts.
+* bad behavior of `insert()` method [#2](https://github.com/CatHood0/dart-quill-delta-simplify/pull/2).
 
 ## 10.8.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * When `startPoint` is passed on `insert()` method of `QueryDelta`, `left` value passed is ignored.
 * When set `target` param in `insert()` method of `QueryDelta`, sometimes the target is replaced unexpectedly.
 * When set `startPoint` is passed, sometimes is ignored and will jump to the part that we want to change.
-* wrong behavior and unexpected `Delta` results after `build()` when using complex inserts.
+* Wrong behavior and unexpected `Delta` results after `build()` when using complex inserts.
 
 ## 10.8.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Fixed 
+
+* When `startPoint` is passed on `insert()` method of `QueryDelta`, `left` value passed is ignored.
+* When set `target` param in `insert()` method of `QueryDelta`, sometimes the target is replaced unexpectedly.
+* When set `startPoint` is passed, sometimes is ignored and will jump to the part that we want to change.
+* wrong behavior and unexpected `Delta` results after `build()` when using complex inserts.
+
 ## 10.8.7
 
 * Fix: removed `flutter_quill` dependency for conflicts with major versions.

--- a/documentation/insert.md
+++ b/documentation/insert.md
@@ -14,16 +14,10 @@ QueryDelta insert({
   required Object? target,
   // An optional parameter indicating the exact offset where 
   // the insertion should start. 
-  //
-  // If it's provided, overrides target and related parameters
   int? startPoint,  
   // A boolean indicating whether to insert to the left or right of the target. 
-  //
-  // It's ignored if startPoint is provided
   bool left = false,
   // A boolean specifying if the insertion should happen only once. 
-  //
-  // It's ignored if startPoint is provided
   bool onlyOnce = false,
   // A boolean indicating whether the inserted object should be part of its own 
   // Operation or merged with the matched target
@@ -34,12 +28,6 @@ QueryDelta insert({
   bool caseSensitive = false,
 }) 
 ```
-
-## Notes
-
-* Providing both `startPoint` and `target` will prioritize `startPoint`, ignoring `target`, `left`, and `onlyOnce`.
-
-* `insert` accepts various types of objects, and each type's behavior is governed by the logic defined in the method and conditions applied during the `build()` phase into `InsertCondition` class.
 
 ## Usage Examples
 
@@ -85,6 +73,7 @@ final BuildResult result = QueryDelta(delta: delta)
     .insert(
         insert: operation, 
         insertAtLastOperation: true, 
+        startPoint: null,
         target: null,
     )
     .build();

--- a/lib/src/extensions/delta_ext.dart
+++ b/lib/src/extensions/delta_ext.dart
@@ -207,7 +207,7 @@ extension EasyDelta on Delta {
           caseSensitive: caseSensitive,
           target: insertAtLastOperation ? null : target,
           left: left,
-          onlyOnce: startPoint != null ? true : onlyOnce,
+          onlyOnce: onlyOnce,
           asDifferentOp: asDifferentOp,
           insertAtLastOperation:
               target == null && (startPoint == null || startPoint < 0)

--- a/lib/src/extensions/query_delta_ext.dart
+++ b/lib/src/extensions/query_delta_ext.dart
@@ -510,10 +510,6 @@ extension EssentialsQueryExt on QueryDelta {
   ///   * [Map<String, dynamic>]
   ///   * [String]
   ///
-  /// # Note
-  /// if [startPoint] is not null, then the object will be inserted at that point
-  /// and [possibleTarget], [left], and [onlyOnce] params will be ignored
-  ///
   /// You can see examples [here](https://github.com/FlutterQuill/dart-quill-delta-simplify/blob/master/documentation/insert.md#usage-examples)
   QueryDelta insert({
     required Object insert,
@@ -529,17 +525,15 @@ extension EssentialsQueryExt on QueryDelta {
     if (target == null && startPoint == null) offset = 0;
     return push(
       InsertCondition(
-        target: offset != null ? null : target,
+        target: target,
         insertion:
             asDifferentOp || insert is Map ? insert.toOperation() : insert,
         range: insertAtLastOperation || offset == null
             ? null
             : DeltaRange.onlyStartPoint(startOffset: offset),
-        left: startPoint != null ? true : left,
-        onlyOnce: startPoint != null ? true : onlyOnce,
-        insertAtLastOperation: startPoint != null || target != null
-            ? false
-            : insertAtLastOperation,
+        left: left,
+        onlyOnce: onlyOnce,
+        insertAtLastOperation: insertAtLastOperation,
         caseSensitive: caseSensitive,
       ),
     );

--- a/lib/src/internals/insert_condition_method.dart
+++ b/lib/src/internals/insert_condition_method.dart
@@ -321,7 +321,7 @@ void _complexMergeInsertsInSameOperation({
       op.clone(
         ofData.substring(
           0,
-          partToMerge.pointByDirection(!isRight),
+          partToMerge.point,
         ),
       ),
     );
@@ -329,7 +329,10 @@ void _complexMergeInsertsInSameOperation({
 
   // adds the match part at the left if the insertion
   // need to be do it at the right part
-  if (isRight) {
+  //
+  // we need to check that we are not at the start index
+  // to avoid create duplicate content parts
+  if (isRight && !isStart) {
     dividedOps.add(
       op.clone(ofData.substring(
         partToMerge.startOffset,
@@ -344,7 +347,9 @@ void _complexMergeInsertsInSameOperation({
   } else if (isOperation) {
     dividedOps.add(insertion);
   }
-  if (!isRight) {
+  // we need to check that we are not at the start index
+  // to avoid create duplicate content parts
+  if (!isRight && !isStart) {
     dividedOps.add(
       op.clone(ofData.substring(
         partToMerge.startOffset,

--- a/lib/src/internals/insert_condition_method.dart
+++ b/lib/src/internals/insert_condition_method.dart
@@ -4,7 +4,6 @@ import 'package:dart_quill_delta_simplify/src/extensions/list_ext.dart';
 import 'package:dart_quill_delta_simplify/src/extensions/operation_ext.dart';
 import 'package:dart_quill_delta_simplify/src/util/typedef.dart';
 import 'package:meta/meta.dart';
-
 import '../util/collections.dart';
 
 @internal
@@ -18,17 +17,21 @@ List<Operation> insertCondition(
   final List<Operation> modifiedOps = <Operation>[];
   final Object insertion = condition.insertion;
   final Object? target = condition.target;
+  final bool shouldAddRangeToIgnorePart =
+      range != null && target != null && range.point > 0;
   final bool isEmbed = insertion is Map;
   final bool isOperation = insertion is Operation && insertion.isInsert;
   final bool isListOperation = insertion is List<Operation>;
+  if (shouldAddRangeToIgnorePart) {
+    partsToIgnore.add(DeltaRange(startOffset: 0, endOffset: range.point));
+  }
   if (insertion is Operation && !insertion.isInsert) return operations;
-  final RegExp? pattern = range != null ||
-          target == null ||
+  final RegExp? pattern = target == null ||
           (target is String && target.isEmpty) ||
-          target is Map<String, dynamic>
+          target is! String
       ? null
       : RegExp(
-          target as String,
+          target,
           caseSensitive: condition.caseSensitive,
         );
   int globalOffset = 0;
@@ -43,6 +46,9 @@ List<Operation> insertCondition(
       isOperation: isOperation,
       isListOperation: isListOperation,
     );
+    if (shouldAddRangeToIgnorePart) {
+      partsToIgnore.removeLast();
+    }
     return modifiedOps.isEmpty ? operations : modifiedOps;
   }
   // main loop
@@ -76,8 +82,8 @@ List<Operation> insertCondition(
         continue;
       }
     }
-    // range
-    if (range != null) {
+    // the range works as expected only when target is null
+    if (range != null && target == null) {
       final int nextGlocalOffset = globalOffset + (opLength);
       final int startOffset = range.startOffset - globalOffset;
       if (nextGlocalOffset > range.startOffset && !onlyAddRest) {
@@ -204,83 +210,79 @@ List<Operation> insertCondition(
         for (RegExpMatch match in matches) {
           final int startOffset = match.start;
           final int endOffset = match.end;
-          // avoid make a change in a part that need to be ignored
-          if (partsToIgnore.ignoreOverlap(DeltaRange(
-              startOffset: startOffset + globalOffset,
-              endOffset: endOffset + globalOffset))) {
-            continue;
-          }
           // ensure to take a correct start offset for insertions when the insertion will be
           // do it at the right of the word
-          final int effectiveOffsetToWord =
-              condition.left ? startOffset : endOffset;
-          deltaPartsToMerge.add(DeltaRange(
-              startOffset: effectiveOffsetToWord, endOffset: endOffset));
+          deltaPartsToMerge.add(
+            DeltaRange(
+              startOffset: startOffset,
+              endOffset: endOffset,
+            ),
+          );
         }
         if (deltaPartsToMerge.isEmpty) {
           modifiedOps.add(op);
           globalOffset += opLength;
           continue;
         }
-        StringBuffer buffer = StringBuffer();
-        List<Operation> dividedOps = <Operation>[];
+        final StringBuffer buffer = StringBuffer();
+        final List<Operation> dividedOps = <Operation>[];
+        final bool isRight = !condition.left;
 
         for (int i = 0; i < deltaPartsToMerge.length; i++) {
           final DeltaRange partToMerge = deltaPartsToMerge.elementAt(i);
           final DeltaRange? nextPartToMerge =
               deltaPartsToMerge.elementAtOrNull(i + 1);
+          final bool shouldIgnorePart = partsToIgnore.ignoreOverlap(
+            DeltaRange(
+                startOffset: partToMerge.startOffset + globalOffset,
+                endOffset: partToMerge.point + globalOffset),
+          );
           if (insertion is String) {
-            if (i == 0) {
+            if (shouldIgnorePart) {
               buffer
-                ..write(ofData.substring(0, partToMerge.startOffset))
+                ..write(
+                    ofData.substring(0, partToMerge.pointByDirection(!isRight)))
                 ..write(insertion)
                 ..write(
                   ofData.substring(
-                    partToMerge.endOffset,
-                    nextPartToMerge?.startOffset,
+                    partToMerge.pointByDirection(!isRight),
+                    nextPartToMerge?.startOffset ?? partToMerge.endOffset,
                   ),
                 );
-            } else {
-              buffer
-                ..write(insertion)
-                ..write(
-                  ofData.substring(
-                    partToMerge.endOffset,
-                    nextPartToMerge?.startOffset,
-                  ),
-                );
+              continue;
             }
-          } else if (i == 0) {
-            dividedOps
-                .add(op.clone(ofData.substring(0, partToMerge.startOffset)));
-            if (isEmbed) {
-              dividedOps.add(Operation.insert(insertion));
-            } else if (isListOperation) {
-              dividedOps.addAll(insertion);
-            } else {
-              dividedOps.add(insertion as Operation);
-            }
-            dividedOps.add(
-              op.clone(ofData.substring(
-                partToMerge.endOffset,
-                nextPartToMerge?.startOffset,
-              )),
+            _mergeInsertsStringsAtSameOperation(
+              buffer: buffer,
+              insertion: insertion,
+              ofData: ofData,
+              partToMerge: partToMerge,
+              nextPartToMerge: nextPartToMerge,
+              condition: condition,
+              index: index,
             );
-          } else {
-            if (isEmbed) {
-              dividedOps.add(Operation.insert(insertion));
-            } else if (isListOperation) {
-              dividedOps.addAll(insertion);
-            } else {
-              dividedOps.add(insertion as Operation);
-            }
+            continue;
+          }
+          if (shouldIgnorePart) {
             dividedOps.add(
               op.clone(
                 ofData.substring(
-                    partToMerge.endOffset, nextPartToMerge?.startOffset),
+                  0,
+                  nextPartToMerge?.startOffset ?? partToMerge.endOffset,
+                ),
               ),
             );
+            continue;
           }
+          _complexMergeInsertsInSameOperation(
+            dividedOps: dividedOps,
+            op: op,
+            ofData: ofData,
+            condition: condition,
+            partToMerge: partToMerge,
+            nextPartToMerge: nextPartToMerge,
+            insertion: insertion,
+            isStart: i == 0,
+          );
         }
         if (buffer.isNotEmpty) modifiedOps.add(op.clone('$buffer'));
         modifiedOps.addAll(dividedOps);
@@ -293,8 +295,102 @@ List<Operation> insertCondition(
     modifiedOps.add(op);
     continue;
   }
+  if (shouldAddRangeToIgnorePart) {
+    partsToIgnore.removeLast();
+  }
   if (modifiedOps.isEmpty) return operations;
   return modifiedOps;
+}
+
+void _complexMergeInsertsInSameOperation({
+  required List<Operation> dividedOps,
+  required Operation op,
+  required String ofData,
+  required InsertCondition condition,
+  required DeltaRange partToMerge,
+  required DeltaRange? nextPartToMerge,
+  required Object insertion,
+  required bool isStart,
+}) {
+  final bool isEmbed = insertion is Map;
+  final bool isOperation = insertion is Operation && insertion.isInsert;
+  final bool isListOperation = insertion is List<Operation>;
+  final bool isRight = !condition.left;
+  if (isStart) {
+    dividedOps.add(
+      op.clone(
+        ofData.substring(
+          0,
+          partToMerge.pointByDirection(!isRight),
+        ),
+      ),
+    );
+  }
+
+  // adds the match part at the left if the insertion
+  // need to be do it at the right part
+  if (isRight) {
+    dividedOps.add(
+      op.clone(ofData.substring(
+        partToMerge.startOffset,
+        partToMerge.endOffset,
+      )),
+    );
+  }
+  if (isEmbed) {
+    dividedOps.add(Operation.insert(insertion));
+  } else if (isListOperation) {
+    dividedOps.addAll(insertion);
+  } else if (isOperation) {
+    dividedOps.add(insertion);
+  }
+  if (!isRight) {
+    dividedOps.add(
+      op.clone(ofData.substring(
+        partToMerge.startOffset,
+        partToMerge.endOffset,
+      )),
+    );
+  }
+  dividedOps.add(
+    op.clone(
+      ofData.substring(
+        partToMerge.endOffset,
+        nextPartToMerge?.startOffset,
+      ),
+    ),
+  );
+}
+
+void _mergeInsertsStringsAtSameOperation({
+  required StringBuffer buffer,
+  required Object insertion,
+  required String ofData,
+  required DeltaRange partToMerge,
+  required DeltaRange? nextPartToMerge,
+  required InsertCondition condition,
+  required int index,
+}) {
+  if (index == 0) {
+    buffer
+      ..write(ofData.substring(0, partToMerge.pointByDirection(condition.left)))
+      ..write(insertion)
+      ..write(
+        ofData.substring(
+          partToMerge.pointByDirection(condition.left),
+          nextPartToMerge?.endOffset,
+        ),
+      );
+  } else {
+    buffer
+      ..write(insertion)
+      ..write(
+        ofData.substring(
+          partToMerge.endOffset,
+          nextPartToMerge?.endOffset,
+        ),
+      );
+  }
 }
 
 void _insertAtLast({

--- a/lib/src/query_delta.dart
+++ b/lib/src/query_delta.dart
@@ -120,8 +120,9 @@ class QueryDelta {
       final bool wasUsedAlready = params.usedConditions.contains(condition.key);
       if (preventReuseConditions && wasUsedAlready) continue;
       if (condition is IgnoreCondition) {
-        if (!wasUsedAlready && !maintainIgnoresConditions)
+        if (!wasUsedAlready && !maintainIgnoresConditions) {
           params.usedConditions.add(condition.key);
+        }
         final len = condition.len ?? -1;
         partsToIgnore.add(
           DeltaRange(
@@ -132,7 +133,9 @@ class QueryDelta {
         continue;
       }
       if (condition is ReplaceCondition &&
-          partsToIgnore.ignoreOverlap(condition.range)) continue;
+          partsToIgnore.ignoreOverlap(condition.range)) {
+        continue;
+      }
       final Object? result =
           condition.build(inputClone, partsToIgnore, onCatch);
       if (!wasUsedAlready) params.usedConditions.add(condition.key);

--- a/lib/src/range/delta_range.dart
+++ b/lib/src/range/delta_range.dart
@@ -1,3 +1,5 @@
+import 'package:dart_quill_delta_simplify/src/extensions/num_ext.dart';
+
 /// Represents a range of character positions within a [Delta] operation.
 ///
 /// This class defines a range using global offsets and provides
@@ -21,6 +23,10 @@ class DeltaRange {
           'endOffset must be equal to or greater than startOffset',
         );
 
+  const DeltaRange.zero()
+      : startOffset = 0,
+        endOffset = 0;
+
   /// Creates a `DeltaRange` with only a starting offset, setting the end offset to `-1`.
   ///
   /// This is useful when the end of the range is not yet defined.
@@ -29,6 +35,15 @@ class DeltaRange {
   }) {
     return DeltaRange(startOffset: startOffset, endOffset: -1);
   }
+
+  /// Return the exact point where ends this DeltaRange
+  int get point => endOffset.nonNegativeInt == 0 ? startOffset : endOffset;
+
+  /// Return the exact point based on the direction passed
+  ///
+  /// If left is true, return startOffset
+  /// If left is false, return endOffset
+  int pointByDirection(bool left) => left ? startOffset : endOffset;
 
   /// Creates a `DeltaRange` from given start and end offsets, or returns `null`
   /// if the inputs are invalid.

--- a/test/dart_quill_delta_simplify_test.dart
+++ b/test/dart_quill_delta_simplify_test.dart
@@ -358,7 +358,7 @@ void main() {
         ..ignorePart(0, len: 50)
         ..insert(
           insert: 'Non ',
-          target: 0,
+          target: null,
           startPoint: 59,
           left: true,
         )
@@ -371,7 +371,7 @@ void main() {
         ..ignorePart(60, len: 20)
         ..insert(
           insert: 's',
-          target: 0,
+          target: null,
           startPoint: 74,
           left: true,
         )
@@ -730,15 +730,48 @@ void main() {
   // using delta only
   group('delta_ext', () {
     test('insert', () {
+      delta
+        ..insert('But, using this experimental test.\n')
+        ..insert('We can test if the experimental changes works as expected\n');
       final Delta expected = Delta()
-        ..insert('Experimental version Delta changed\n');
+        ..insert('Experimental Delta version Delta\n')
+        ..insert('But, using this experimental Delta test.\n')
+        ..insert(
+            'We can test if the experimental Delta changes works as expected\n');
       delta.simpleInsert(
-          insert: ' changed',
-          target: 'Delta',
-          caseSensitive: true,
-          startPoint: null);
+        insert: ' Delta',
+        target: 'Experimental',
+        startPoint: null,
+        left: false,
+        onlyOnce: false,
+      );
       expect(delta, expected);
     });
+
+    test('complex insert', () {
+      delta
+        ..insert('But, using this experimental Delta test.\n')
+        ..insert(
+            'We can test if the experimental Delta changes works as expected\n');
+      final Delta expected = Delta()
+        ..insert('Experimental version Delta')
+        ..insert({'img': 'my/image/path/to/file.png'})
+        ..insert('\nBut, using this experimental Delta')
+        ..insert({'img': 'my/image/path/to/file.png'})
+        ..insert(' test.\n')
+        ..insert('We can test if the experimental Delta')
+        ..insert({'img': 'my/image/path/to/file.png'})
+        ..insert(' changes works as expected\n');
+      delta.simpleInsert(
+        insert: {'img': 'my/image/path/to/file.png'},
+        target: 'Delta',
+        startPoint: null,
+        left: false,
+        onlyOnce: false,
+      );
+      expect(delta, expected);
+    });
+
     test('delete', () {
       final Delta expected = Delta()..insert('Experimental version \n');
       delta.simpleDelete(


### PR DESCRIPTION
## Description

Fixed an issue where using the `QueryDelta` `insert()` method with complex inserts would suddenly replace `targets` (if they were passed) or even not insert in the correct position depending on the value passed in `left`.

Previously, a `Delta` like this:

```dart
final Delta delta = Delta()
  ..insert('Experimental Delta version Delta\n');

// apply the change
delta.simpleInsert(
  insert: {'img': 'my/image/path/to/file.png'},
  target: 'Delta',
  startPoint: null,
  left: false,
  onlyOnce: false,
);
```

Would return this:

_As you can see, the match part is removed unexpectedly when there are more than one match into the same `Operation`_.

```console
Delta: [
  {'insert': 'Experimental '},
  {'insert': {'img': 'my/image/path/to/file.png'}},
  {'insert': ' version '},
  {'insert': {'img': 'my/image/path/to/file.png'}},
  {'insert': '\n'},
],
```

But now, the content is pasted as expected at the correct part. It returns the `Delta` that we expect:

```console
Delta: [
  {'insert': 'Experimental Delta'},
  {'insert': {'img': 'my/image/path/to/file.png'}},
  {'insert': ' version Delta'},
  {'insert': {'img': 'my/image/path/to/file.png'}},
  {'insert': '\n'},
],
```

### Some fixes that this PR includes are:

* When `startPoint` is passed on `insert()` method of `QueryDelta`, `left` value passed is ignored.
* When set `target` param in `insert()` method of `QueryDelta`, sometimes the target is replaced unexpectedly.
* When set `startPoint` is passed, sometimes is ignored and will jump to the part that we want to change.
* Wrong behavior and unexpected `Delta` results after `build()` when using complex inserts.

## Related Issues

_N/A_

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [x] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [x] 🧪 **Tests:** New or modified tests
- [x] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
