### PR TITLE
Feat: added dynamic replace method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+* `replaceAllMapped` to allow create operations dynamically based on the matched `Operation` [#3](https://github.com/CatHood0/dart-quill-delta-simplify/pull/3).
+
 ### Fixed 
 
 * bad behavior of `insert()` method [#2](https://github.com/CatHood0/dart-quill-delta-simplify/pull/2).

--- a/documentation/replace.md
+++ b/documentation/replace.md
@@ -16,6 +16,7 @@ QueryDelta replace({
 
 ## Usage Examples
 
+
 ### Simple Text Replacement
 
 ```dart
@@ -80,4 +81,56 @@ final BuildResult result = QueryDelta(delta: delta)
     )
     .build();
 print(result.delta); // [{"insert": "Hello Dart! and Hello world 2⏎"}] 
+```
+
+## Dynamic replace method
+
+```dart 
+/// It's very similar to [replaceAllMapped] from String class
+QueryDelta replaceAllMapped({
+  required OperationBuilder replace, 
+  required String target, 
+  bool caseSensitive = false,
+})
+```
+
+## Usage Example for `replaceAllMapped`
+
+```dart
+final Delta delta = Delta()
+  ..insert('Experimental version Delta\n')
+  ..insert('![](https:'
+    '//encrypted-tbn0.gstatic.com'
+    '/images?q=tbn:'
+    'ANd9GcT_G1EXGbaNjBcx_u14jkW7NCQmJibMOr-EwQ&s)'
+    '\n');
+// basic markdown image pattern (just created for example purposes)
+final RegExp pattern = RegExp(r'!\[\]\((.+?)\)');
+final BuildResult result = QueryDelta(delta: delta)
+ .replaceAllMapped(
+   replaceBuilder: (
+     String data,
+     Map<String, dynamic>? currentOperationAttributes,
+     DeltaRange currentRange,
+     DeltaRange matchRange,
+   ) {
+     if (pattern.hasMatch(data)) {
+       final rMatch = pattern.firstMatch(data)!;
+       final String image = rMatch.group(1)!;
+       return <Operation>[Operation.insert(<String, dynamic>{'image': image})];
+     }
+     return <Operation>[];
+   },
+   target: pattern.pattern,
+   caseSensitive: false,
+ )
+ .build();
+debugPrint(result.delta.toString());
+/*
+[
+ {'insert': 'Experimental version Delta\n'},
+ {'insert': {'image': 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_G1EXGbaNjBcx_u14jkW7NCQmJibMOr-EwQ&s'}},
+ {'insert': '\n'},
+]
+*/
 ```

--- a/lib/src/conditions/replace.dart
+++ b/lib/src/conditions/replace.dart
@@ -39,7 +39,8 @@ class ReplaceCondition extends Condition<List<Operation>> {
             replace is Operation ||
                 replace is Iterable<Operation> ||
                 replace is String ||
-                replace is Map,
+                replace is Map ||
+                replace is OperationBuilder,
             'replace of type ${replace.runtimeType}, only can be String or Map');
 
   @override

--- a/lib/src/extensions/query_delta_ext.dart
+++ b/lib/src/extensions/query_delta_ext.dart
@@ -5,6 +5,7 @@ import 'package:dart_quill_delta_simplify/src/extensions/operation_ext.dart';
 import 'package:dart_quill_delta_simplify/src/extensions/string_ext.dart';
 import 'package:dart_quill_delta_simplify/src/util/check_op_attrs.dart';
 import 'package:dart_quill_delta_simplify/src/util/delta/denormalizer_ext.dart';
+import 'package:dart_quill_delta_simplify/src/util/typedef.dart';
 import '../util/collections.dart';
 import '../util/op_offset_to_char_offset.dart';
 
@@ -607,12 +608,34 @@ extension EssentialsQueryExt on QueryDelta {
       throw Exception(
           'target and range are null or invalid to use. Them cannot be null');
     }
+    assert(replace is! Function, 'replace cannot be a function');
     return push(
       ReplaceCondition(
         target: target,
         replace: replace,
         range: range,
         onlyOnce: range != null ? true : onlyOnce,
+        caseSensitive: caseSensitive,
+      ),
+    );
+  }
+
+  /// Replaces a portion of text with a callback that return a dynamic operations based
+  /// on the values passed during build (similar to `replaceAllMapped` of String class).
+  QueryDelta replaceAllMapped({
+    required OperationBuilder replaceBuilder,
+    required String target,
+    bool caseSensitive = false,
+  }) {
+    if (target.isEmpty) {
+      throw Exception('target cannot be empty');
+    }
+    return push(
+      ReplaceCondition(
+        target: target,
+        replace: replaceBuilder,
+        range: null,
+        onlyOnce: false,
         caseSensitive: caseSensitive,
       ),
     );

--- a/lib/src/internals/replace_part_condition_method.dart
+++ b/lib/src/internals/replace_part_condition_method.dart
@@ -35,6 +35,7 @@ List<Operation> replaceCondition(
   final bool isListOperation = replace is Iterable<Operation>;
   final bool isOperation = replace is Operation;
   final bool isEmbed = replace is Map && !isOperation && !isListOperation;
+  final bool isOperationBuilder = replace is OperationBuilder;
   for (int index = 0; index < operations.length; index++) {
     final Operation op = operations.elementAt(index);
     final Object? data = op.data;
@@ -143,15 +144,26 @@ List<Operation> replaceCondition(
           final String rightPart = data is! String
               ? ''
               : data.substring(endOffset > opLength ? opLength : endOffset);
-          final Operation mainOp = Operation.insert(
-            '$leftPart$replace$rightPart',
-            data is Map ? null : op.attributes,
-          );
-          if (mainOp.ignoreIfEmpty) {
+          final Iterable<Operation> mainOp = isOperationBuilder
+              ? replace(
+                  data.toString().substring(startOffset, endOffset),
+                  op.attributes,
+                  DeltaRange(
+                      startOffset: globalOffset,
+                      endOffset: globalOffset + opLength),
+                  DeltaRange(startOffset: startOffset, endOffset: endOffset),
+                )
+              : <Operation>[
+                  Operation.insert(
+                    '$leftPart$replace$rightPart',
+                    data is Map ? null : op.attributes,
+                  )
+                ];
+          if (mainOp.isEmpty) {
             globalOffset += opLength;
             continue;
           }
-          modifiedOps.add(mainOp);
+          modifiedOps.addAll(mainOp);
         }
       }
       addRestOfOps = true;
@@ -167,7 +179,7 @@ List<Operation> replaceCondition(
           globalOffset += opLength;
           continue;
         }
-        Object? mainOp = null;
+        Object? mainOp;
         if (isEmbed || replace is String) {
           mainOp = op.clone(replace, null, false, isEmbed);
           modifiedOps.add(mainOp as Operation);
@@ -177,6 +189,12 @@ List<Operation> replaceCondition(
         } else if (isListOperation) {
           mainOp = replace;
           modifiedOps.addAll(mainOp as Iterable<Operation>);
+        } else if (isOperationBuilder) {
+          assert(() {
+            print(
+                'Couldn\'t be added the replace data, since, the matched part is a Map and the replace is a Function');
+            return true;
+          }(), '');
         }
         if (condition.onlyOnce) addRestOfOps = true;
         globalOffset += opLength;
@@ -206,8 +224,8 @@ List<Operation> replaceCondition(
         globalOffset += opLength;
         continue;
       }
-      StringBuffer buffer = StringBuffer();
-      List<Operation> dividedOps = <Operation>[];
+      final StringBuffer buffer = StringBuffer();
+      final List<Operation> dividedOps = <Operation>[];
 
       for (int i = 0; i < deltaPartsToMerge.length; i++) {
         final DeltaRange partToMerge = deltaPartsToMerge.elementAt(i);
@@ -240,8 +258,20 @@ List<Operation> replaceCondition(
             dividedOps.add(Operation.insert(replace));
           } else if (isListOperation) {
             dividedOps.addAll(replace);
-          } else {
-            dividedOps.add(replace as Operation);
+          } else if (isOperation) {
+            dividedOps.add(replace);
+          } else if (isOperationBuilder) {
+            final Iterable<Operation> opBuilded = replace(
+              data.substring(partToMerge.startOffset, partToMerge.endOffset),
+              op.clone(null).attributes,
+              DeltaRange(
+                  startOffset: globalOffset,
+                  endOffset: globalOffset + opLength),
+              partToMerge,
+            );
+            if (opBuilded.isNotEmpty) {
+              dividedOps.addAll(opBuilded);
+            }
           }
           dividedOps.add(
             Operation.insert(
@@ -257,12 +287,28 @@ List<Operation> replaceCondition(
             dividedOps.add(Operation.insert(replace));
           } else if (isListOperation) {
             dividedOps.addAll(replace);
-          } else {
-            dividedOps.add(replace as Operation);
+          } else if (isOperation) {
+            dividedOps.add(replace);
+          } else if (isOperationBuilder) {
+            final Iterable<Operation> opBuilded = replace(
+              data.substring(partToMerge.startOffset, partToMerge.endOffset),
+              op.clone(null).attributes,
+              DeltaRange(
+                  startOffset: globalOffset,
+                  endOffset: globalOffset + opLength),
+              partToMerge,
+            );
+            if (opBuilded.isNotEmpty) {
+              dividedOps.addAll(opBuilded);
+            }
           }
           dividedOps.add(
-            op.clone(data.substring(
-                partToMerge.endOffset, nextPartToMerge?.startOffset)),
+            op.clone(
+              data.substring(
+                partToMerge.endOffset,
+                nextPartToMerge?.startOffset,
+              ),
+            ),
           );
         }
         //end of match loop

--- a/lib/src/util/typedef.dart
+++ b/lib/src/util/typedef.dart
@@ -1,1 +1,10 @@
+import 'package:dart_quill_delta/dart_quill_delta.dart';
+import 'package:dart_quill_delta_simplify/delta_ranges.dart';
+
 typedef OnCatchCallback = void Function(Exception);
+typedef OperationBuilder = Iterable<Operation> Function(
+  String data,
+  Map<String, dynamic>? currentOperationAttributes,
+  DeltaRange currentRange,
+  DeltaRange matchRange,
+);

--- a/test/dart_quill_delta_simplify_test.dart
+++ b/test/dart_quill_delta_simplify_test.dart
@@ -189,6 +189,47 @@ void main() {
         ..build();
       expect(query.toDelta(), expected);
     });
+
+    test('should replace markdown image with a valid embed operation', () {
+      final image = {
+        'image': 'https:'
+            '//encrypted-tbn0.gstatic.com'
+            '/images?q=tbn:'
+            'ANd9GcT_G1EXGbaNjBcx_u14jkW7NCQmJibMOr-EwQ&s',
+      };
+      delta.insert('![](https:'
+          '//encrypted-tbn0.gstatic.com'
+          '/images?q=tbn:'
+          'ANd9GcT_G1EXGbaNjBcx_u14jkW7NCQmJibMOr-EwQ&s)'
+          '\n');
+      final RegExp pattern = RegExp(r'!\[\]\((.+?)\)');
+      final Delta expected = Delta()
+        ..insert('Experimental version Delta\n')
+        ..insert(image)
+        ..insert('\n');
+      final QueryDelta query = QueryDelta(delta: delta)
+        ..replaceAllMapped(
+          replaceBuilder: (
+            String data,
+            Map<String, dynamic>? currentOperationAttributes,
+            DeltaRange currentRange,
+            DeltaRange matchRange,
+          ) {
+            if (pattern.hasMatch(data)) {
+              final rMatch = pattern.firstMatch(data)!;
+              final String image = rMatch.group(1)!;
+              return <Operation>[
+                Operation.insert(<String, dynamic>{'image': image})
+              ];
+            }
+            return <Operation>[];
+          },
+          target: pattern.pattern,
+          caseSensitive: false,
+        )
+        ..build();
+      expect(query.toDelta(), expected);
+    });
   });
   // format
   group('format', () {


### PR DESCRIPTION
## Description

A method has been added that works almost identically to the String class's `replaceAllMapped` method. This was done to give us the flexibility to create inserts/replacements more dynamically (for example, when we want to replace images that have Markdown syntax and we want to transform that `Markdown` string into a **Quill Delta** `EmbedObject`).

## Related Issues

_N/A_

## Type of Change

- [x] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [x] 🧪 **Tests:** New or modified tests
- [x] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
